### PR TITLE
Add basic .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+.idea


### PR DESCRIPTION
I noticed that there is no `.gitignore` file, so git tried to add things that shouldn't be added. To prevent accidentally adding generated files I'd like to add a (basic) `.gitignore` file.